### PR TITLE
Fix variables for expiration Month and Year

### DIFF
--- a/flex-js-sample/Views/Home/Checkout.cshtml
+++ b/flex-js-sample/Views/Home/Checkout.cshtml
@@ -119,8 +119,8 @@
                 cardInfo: {
                     cardNumber: document.querySelector('#cardNumber').value,
                     cardType: document.querySelector('#cardType').value,
-                    expiryMonth: document.querySelector('#expiryMonth').value,
-                    expiryYear: document.querySelector('#expiryYear').value
+                    cardExpirationMonth: document.querySelector('#expiryMonth').value,
+                    cardExpirationYear: document.querySelector('#expiryYear').value
                 },
                 encryptionType: 'rsaoaep256'
                 // production: true // without specifying this tokens are created in test env


### PR DESCRIPTION
Variable names were wrong, causing the SDK to always tokenize the card with dummy values on the expiration date.